### PR TITLE
Bump plugin-project to 5.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "groovy"
-    id "org.openmicroscopy.plugin-project" version "5.5.1"
+    id "org.openmicroscopy.plugin-project" version "5.6.0"
 }
 
 group = "org.openmicroscopy"


### PR DESCRIPTION
Bump plugin-project to 5.6.0 to fix javadoc generation issue
See https://github.com/ome/omero-artifact-plugin/pull/21